### PR TITLE
feat: add simple and detailed scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,20 @@ Response:
 {
   "model_version": "v1.2.0",
   "score": 0.83,
+  "risk_level": "high"
+}
+```
+
+### POST /api/v1/churn/score/detail
+Request:
+```json
+{ "user_id": "uuid", "prod_id": "PROD123" }
+```
+Response:
+```json
+{
+  "model_version": "v1.2.0",
+  "score": 0.83,
   "risk_level": "high",
   "top_factors": [
     {"name": "cancel_page_visit_14d", "contribution": 0.21}

--- a/ai-service/src/main/java/com/subhub/ai/controller/ScoreController.java
+++ b/ai-service/src/main/java/com/subhub/ai/controller/ScoreController.java
@@ -1,12 +1,15 @@
 
 package com.subhub.ai.controller;
-import com.subhub.ai.dto.*; import com.subhub.ai.service.ScoringService;
+import com.subhub.ai.dto.*; import com.subhub.ai.service.ScoreService;
 import org.springframework.web.bind.annotation.*; import reactor.core.publisher.Mono; import reactor.core.scheduler.Schedulers;
 @RestController @RequestMapping("/api/v1/churn")
 public class ScoreController {
-  private final ScoringService scoring;
-  public ScoreController(ScoringService s){ this.scoring=s; }
-  @PostMapping("/score") public Mono<ScoreRes> score(@RequestBody ScoreReq req){
-    return Mono.fromCallable(() -> scoring.score(req.userId(), req.prodId())).subscribeOn(Schedulers.boundedElastic());
+  private final ScoreService scoring;
+  public ScoreController(ScoreService s){ this.scoring=s; }
+  @PostMapping("/score") public Mono<SimpleScoreRes> simpleScore(@RequestBody ScoreReq req){
+    return Mono.fromCallable(() -> scoring.simpleScore(req.userId(), req.prodId())).subscribeOn(Schedulers.boundedElastic());
+  }
+  @PostMapping("/score/detail") public Mono<ScoreRes> detailScore(@RequestBody ScoreReq req){
+    return Mono.fromCallable(() -> scoring.detailScore(req.userId(), req.prodId())).subscribeOn(Schedulers.boundedElastic());
   }
 }

--- a/ai-service/src/main/java/com/subhub/ai/dto/Dto.java
+++ b/ai-service/src/main/java/com/subhub/ai/dto/Dto.java
@@ -4,3 +4,4 @@ import java.util.*; public record ScoreReq(UUID userId, String prodId) {}
 public record Factor(String name, double contribution) {}
 public record Recommendation(String action, String reason, Map<String,Object> params) {}
 public record ScoreRes(String requestId, String modelVersion, double score, String riskLevel, List<Factor> topFactors, Recommendation recommendation) {}
+public record SimpleScoreRes(String requestId, String modelVersion, double score, String riskLevel) {}

--- a/ai-service/src/main/java/com/subhub/ai/service/ScoreService.java
+++ b/ai-service/src/main/java/com/subhub/ai/service/ScoreService.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service;
 import java.util.*;
 
 @Service
-public class ScoringService {
+public class ScoreService {
 
   private static final int TOP_N = 3;
 
@@ -21,7 +21,7 @@ public class ScoringService {
 
   private final FeatureAssembler features;
 
-  public ScoringService(FeatureAssembler f) {
+  public ScoreService(FeatureAssembler f) {
     this.features = f;
   }
 
@@ -37,7 +37,7 @@ public class ScoringService {
     session = env.createSession(modelPath, new OrtSession.SessionOptions());
   }
 
-  public ScoreRes score(java.util.UUID userId, String prodId) throws Exception {
+  private ScoreRes score(java.util.UUID userId, String prodId) throws Exception {
     double[] f = features.assemble(userId, prodId);
     float[] ff = new float[f.length];
     for (int i = 0; i < f.length; i++) {
@@ -67,6 +67,15 @@ public class ScoringService {
       String risk = score >= 0.8 ? "high" : score >= 0.5 ? "med" : "low";
       return new ScoreRes(java.util.UUID.randomUUID().toString(), "churn_v1", score, risk, topFactors, null);
     }
+  }
+
+  public SimpleScoreRes simpleScore(java.util.UUID userId, String prodId) throws Exception {
+    ScoreRes res = score(userId, prodId);
+    return new SimpleScoreRes(res.requestId(), res.modelVersion(), res.score(), res.riskLevel());
+  }
+
+  public ScoreRes detailScore(java.util.UUID userId, String prodId) throws Exception {
+    return score(userId, prodId);
   }
 }
 


### PR DESCRIPTION
## Summary
- split score service into `simpleScore` returning score with risk only and `detailScore` including top factors
- expose `/score` for simple results and `/score/detail` for detailed results
- add `SimpleScoreRes` DTO and update docs for lightweight responses

## Testing
- `gradle test` *(fails: Could not find ai.onnxruntime:onnxruntime:1.18.1)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e71f23d88327bf9d72a51016a606